### PR TITLE
Update dependencies and Travis metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: node_js
-sudo: false
 before_install:
   - "npm install -g npm@latest"
 node_js:
-  - '0.8'
-  - '0.10'
-  - '0.12'
-  - 'iojs'
-  - '4'
-  - '5'
-  - '6'
+  - node
+  - lts/*

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "tap": "^2.3.1"
+    "tap": "^14.10.6"
   },
   "scripts": {
     "test": "tap --coverage test/*.js"


### PR DESCRIPTION
# What / Why

Sweeping floors, dusting surfaces, patching vulns. :hammer_and_wrench: 

  * Old `tap` pulls in deps that have vulnerabilities like https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-7598 (I had an `npm audit` warning about this, and tracked it down to here...)
  * A bunch of packages on npm depend on this one. Weekly downloads still increasing. https://www.npmjs.com/package/wrappy
  * Having Travis just target whatever is newest Node + LTS should ease maintenance burden.

## References

n/a